### PR TITLE
Added javadoc comments, and signals example.

### DIFF
--- a/examples/signals/SignalsExample.java
+++ b/examples/signals/SignalsExample.java
@@ -1,0 +1,139 @@
+/*
+ *
+ *
+ * Copyright 2018 The Symphony Software Foundation
+ *
+ * Licensed to The Symphony Software Foundation (SSF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package signals;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.symphonyoss.client.SymphonyClient;
+import org.symphonyoss.client.SymphonyClientConfig;
+import org.symphonyoss.client.SymphonyClientFactory;
+import org.symphonyoss.client.SymphonyClientFactory.TYPE;
+import org.symphonyoss.client.exceptions.SignalsException;
+import org.symphonyoss.symphony.agent.invoker.ApiException;
+import org.symphonyoss.symphony.clients.model.SymSignal;
+
+/**
+ * Simple example to list signals
+ * <p>
+ * It will send a message to a call.home.user and listen/create new Chat
+ * sessions.
+ * <p>
+ * <p>
+ * <p>
+ * REQUIRED VM Arguments or System Properties:
+ * <p>
+ * -Dtruststore.file= -Dtruststore.password=password
+ * -Dsessionauth.url=https://(hostname)/sessionauth
+ * -Dkeyauth.url=https://(hostname)/keyauth
+ * -Duser.call.home=frank.tarsillo@markit.com -Duser.cert.password=password
+ * -Duser.cert.file=bot.user2.p12 -Duser.email=bot.user2@domain.com
+ * -Dpod.url=https://(pod host)/pod -Dagent.url=https://(agent server
+ * host)/agent -Dreceiver.email=bot.user2@markit.com or bot user email
+ *
+ * @author Dov Katz
+ */
+// NOSONAR
+public class SignalsExample {
+
+	private final Logger logger = LoggerFactory.getLogger(SignalsExample.class);
+	private SymphonyClient symClient;
+
+	public SignalsExample() {
+
+		init();
+
+	}
+
+	public static void main(String[] args) {
+
+		new SignalsExample();
+
+	}
+
+	public void init() {
+		logger.info("Signal Client example starting...");
+
+		try {
+
+			// Create an initialized client
+			symClient = SymphonyClientFactory.getClient(TYPE.V4);
+			symClient.init(new SymphonyClientConfig(true));
+			logger.info("My bot email is {}", symClient.getLocalUser().getEmailAddress());
+			logger.info("My bot' name is {}", symClient.getLocalUser().getDisplayName());
+
+			// List Signals
+			List<SymSignal> signals = symClient.getSignalsClient().listSignals(0, 10);
+			logger.info("Found (max 10) {} signals", signals.size());
+			signals.forEach(signal -> {
+				logger.info("Signal :{}", signal);
+			});
+
+			// Create Signal
+			SymSignal signal = new SymSignal();
+			signal.setVisibleOnProfile(false);
+			signal.setName("Test Signal " + System.currentTimeMillis());
+			signal.setQuery("HASHTAG:testSignal AND CASHTAG:money");
+			signal.setCompanyWide(false);
+			;
+			logger.info("Going to create a signal : Name {}, Query: {}", signal.getName(), signal.getQuery());
+			;
+			SymSignal result = symClient.getSignalsClient().createSignal(signal);
+			logger.info("Created Signal ID {}, Name {}", result.getId(), result.getName());
+			;
+
+			// Search for the one we just created
+			logger.info("Let's search for our new signal");
+			SymSignal found = symClient.getSignalsClient().getSignal(result.getId());
+			logger.info("Found signal we just created by ID {} --> {} ( {} )", result.getId(), found.getName(),
+					found.getQuery());
+
+			// Delete Signal
+			logger.info("Let's delete our signal");
+			symClient.getSignalsClient().deleteSignal(result.getId());
+			logger.info("Deleted Signal {},  Let's prove it", result.getId());
+
+			// Search for the one we just deleted
+			try {
+				found = symClient.getSignalsClient().getSignal(result.getId());
+				logger.info("We didn't delete the signal,  it seems this was found {}: ",found);
+			} catch (SignalsException sigExc) {
+				if (sigExc.getCause() instanceof ApiException && ((ApiException) sigExc.getCause()).getCode() == 404) {
+					logger.info(
+							"Successfully got a 404 when trying to search for a non-existent signal. Deletion succeeded");
+					;
+				}
+			}
+			logger.info("Client shutting down.");
+			symClient.shutdown();
+			System.exit(0);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+	}
+
+}

--- a/symphony-client/src/main/java/org/symphonyoss/symphony/clients/impl/SignalsClientImpl.java
+++ b/symphony-client/src/main/java/org/symphonyoss/symphony/clients/impl/SignalsClientImpl.java
@@ -21,7 +21,6 @@
  * under the License.
  *
  */
-
 /**
  * @author dovkatz on 03/13/2018
  */
@@ -90,6 +89,16 @@ public class SignalsClientImpl implements SignalsClient {
 		apiClient.setBasePath(config.get(SymphonyClientConfigID.AGENT_URL));
 	}
 
+	/**
+	 * Creates a signal based on a given query
+	 *
+	 * @param signal
+	 *            The Signal object containing the query, name, and
+	 *            visibility/company-wide settings to use
+	 *
+	 * @return the SymSignal object that was created, including the timestamp, and
+	 *         ID
+	 */
 	@Override
 	public SymSignal createSignal(SymSignal signal) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -103,6 +112,18 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Updates an existing signal
+	 * 
+	 * @param id
+	 *            The ID of the signal to be updated
+	 * 
+	 * @param signal
+	 *            The SymSignal object containing the updated fields
+	 *
+	 * @return the SymSignal object that was updated
+	 * 
+	 */
 	@Override
 	public SymSignal updateSignal(String id, SymSignal signal) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -116,6 +137,13 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Deletes an existing signal
+	 * 
+	 * @param id
+	 *            The ID of the signal to be deleted
+	 * 
+	 */
 	@Override
 	public void deleteSignal(String id) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -126,6 +154,16 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Retrieves an existing signal. Can be public signals, or signals owned by the
+	 * current session owner
+	 * 
+	 * @param id
+	 *            The ID of the signal to be updated
+	 * 
+	 * @return the SymSignal object with that ID
+	 * 
+	 */
 	@Override
 	public SymSignal getSignal(String id) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -138,6 +176,19 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Lists all signals owned by or subscribed to by the current session owner.
+	 * 
+	 * @param skip
+	 *            Offset - number of items to skip in the list
+	 * 
+	 * @param limit
+	 *            Maximum number of results to return (Hard maximum according to
+	 *            REST API is 500)
+	 * 
+	 * @return List of SymSignal instances
+	 * 
+	 */
 	@Override
 	public List<SymSignal> listSignals(int skip, int limit) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -150,6 +201,22 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Lists all subscribers of a given signal
+	 * 
+	 * @param id
+	 *            ID of the signal
+	 * 
+	 * @param skip
+	 *            Offset - number of items to skip in the list
+	 * 
+	 * @param limit
+	 *            Maximum number of results to return (Hard maximum according to
+	 *            REST API is 500)
+	 * 
+	 * @return List of subscribers
+	 * 
+	 */
 	@Override
 	public SymChannelSubscriberResponse listSubscribers(String id, BigDecimal skip, BigDecimal limit)
 			throws SignalsException {
@@ -163,6 +230,15 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Subscribes the current session owner to a given signal
+	 * 
+	 * @param id
+	 *            ID of the signal
+	 * 
+	 * @return API response of subscription operation
+	 * 
+	 */
 	@Override
 	public ChannelSubscriptionResponse subscribe(String id) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -174,6 +250,22 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Subscribes the set of specified users to a given symbol
+	 * 
+	 * @param id
+	 *            ID of the signal
+	 * 
+	 * @param pushed
+	 *            Force-push the signal (they cannot unsubscribe)
+	 * 
+	 * @param userIds
+	 *            List of userIDs to subscribe (maximum 100 per operation per REST
+	 *            API Docs)
+	 * 
+	 * @return API response of subscription operation
+	 * 
+	 */
 	@Override
 	public ChannelSubscriptionResponse bulkSubscribe(String id, boolean pushed, List<BigDecimal> userIds)
 			throws SignalsException {
@@ -186,6 +278,15 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Unsubscribes the session owner of specified users to a given symbol
+	 * 
+	 * @param id
+	 *            ID of the signal
+	 *            
+	 * @return API response of unsubscription operation
+	 * 
+	 */
 	@Override
 	public ChannelSubscriptionResponse unsubscribe(String id) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);
@@ -197,6 +298,19 @@ public class SignalsClientImpl implements SignalsClient {
 		}
 	}
 
+	/**
+	 * Unsubscribes the set of specified users to a given symbol
+	 * 
+	 * @param id
+	 *            ID of the signal
+	 * 
+	 * @param userIds
+	 *            List of userIDs to unsubscribe (maximum 100 per operation per REST
+	 *            API Docs)
+	 * 
+	 * @return API response of unsubscription operation
+	 * 
+	 */
 	@Override
 	public ChannelSubscriptionResponse bulkUnsubscribe(String id, List<BigDecimal> userIds) throws SignalsException {
 		SignalsApi api = new SignalsApi(apiClient);


### PR DESCRIPTION
New example (tested locally against foundation pod) creates, deletes, lists, and searches by ID for signals.